### PR TITLE
README, correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ of the maven project and then type the following (for `SimpleDeposit`):
 
     mvn clean install
     mvn dependency:copy-dependencies
-    java -cp target/dependency/*:target/easy-sword2-dans-examples.jar nl.knaw.dans.easy.sword2examples.SimpleDeposit \
+    java -cp "target/dependency/*:target/easy-sword2-dans-examples.jar" nl.knaw.dans.easy.sword2examples.SimpleDeposit \
        src/test/resources/examples/example.zip https://act.easy.dans.knaw.nl/sword2/collection/1 <username> <password>
 
 This of course assumes that you have first zipped the example bag to the `src/test/resources/examples` sub-directory.


### PR DESCRIPTION
The command line for 'running from project dir' doesn't work from my Mac without quotes around the class path, maybe due to the asterisk involved
